### PR TITLE
Optional Secrets and Go Version input

### DIFF
--- a/.github/workflows/reusable-helm-deploy.yaml
+++ b/.github/workflows/reusable-helm-deploy.yaml
@@ -4,13 +4,17 @@ on:
   workflow_call:
     secrets:
       GHA_ACCESS_USER:
-        required: true
+        required: false
+        description: 'Required for Golang services to download private Go modules during Docker image builds.'
       GHA_ACCESS_TOKEN:
-        required: true
+        required: false
+        description: 'Required for Golang services to download private Go modules during Docker image builds.'
       BUF_USER:
-        required: true
+        required: false
+        description: 'Required for Golang services to access private Buf registries during Docker image builds.'
       BUF_TOKEN:
-        required: true
+        required: false
+        description: 'Required for Golang and frontend services to access private Buf registries during Docker image builds.'
 
 jobs:
   push_docker_image:

--- a/.github/workflows/reusable-verify-go-microservice.yaml
+++ b/.github/workflows/reusable-verify-go-microservice.yaml
@@ -2,6 +2,11 @@ name: Verify Go Microservice
 
 on:
   workflow_call:
+    inputs:
+      go-version:
+        type: string
+        required: false
+        default: '^1.20'
     secrets:
       GHA_ACCESS_USER:
         required: true
@@ -69,7 +74,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.20'
+          go-version: ${{ inputs.go-version }}
 
       - name: Setup Private Modules
         run: git config --global url."https://${{ secrets.GHA_ACCESS_USER }}:${{ secrets.GHA_ACCESS_TOKEN }}@github.com".insteadOf "https://github.com"


### PR DESCRIPTION
# Overview
- Make secrets in helm-deploy `workflow_call` optional for actions that do not need to provide PATs and Buf tokens to the Docker image args.
- Add optional `go-version` input to verify-go-microservice `workflow_call` to allow overriding the version used in actions/setup-go.