### PR TITLE
Refactor Helm Deploy Workflow Call

### DIFF
--- a/.github/workflows/reusable-helm-deploy.yaml
+++ b/.github/workflows/reusable-helm-deploy.yaml
@@ -2,6 +2,12 @@ name: Deploy Kubernetes Application
 
 on:
   workflow_call:
+    inputs:
+      skip_docker_image:
+        default: false
+        required: false
+        type: boolean
+        description: Boolean flag to skip the docker build and publish steps of the workflow. Used for helm deploys that do not require their own Docker image.
     secrets:
       GHA_ACCESS_USER:
         required: false
@@ -34,8 +40,10 @@ jobs:
 
     steps:
       - uses: docker/setup-buildx-action@v2
+        if: !inputs.skip_docker_image
 
       - uses: docker/login-action@v2
+        if: !inputs.skip_docker_image
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -56,6 +64,7 @@ jobs:
           environment: ${{ steps.docker.outputs.environment }}
 
       - name: Build and Push Docker Image
+        if: !inputs.skip_docker_image
         uses: docker/build-push-action@v3
         with:
           push: true

--- a/.github/workflows/reusable-helm-deploy.yaml
+++ b/.github/workflows/reusable-helm-deploy.yaml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - uses: docker/setup-buildx-action@v2
-        if: !inputs.skip_docker_image
+        if: ${{ !inputs.skip_docker_image }}
 
       - uses: docker/login-action@v2
-        if: !inputs.skip_docker_image
+        if: ${{ !inputs.skip_docker_image }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -64,7 +64,7 @@ jobs:
           environment: ${{ steps.docker.outputs.environment }}
 
       - name: Build and Push Docker Image
-        if: !inputs.skip_docker_image
+        if: ${{ !inputs.skip_docker_image }}
         uses: docker/build-push-action@v3
         with:
           push: true

--- a/.github/workflows/reusable-helm-deploy.yaml
+++ b/.github/workflows/reusable-helm-deploy.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         description: Boolean flag to skip the docker build and publish steps of the workflow. Used for helm deploys that do not require their own Docker image.
+      chart_path:
+        default: deployments/helm/${{ github.event.repository.name }}
+        required: false
+        type: string
+        description: 'Path to Helm chart'
     secrets:
       GHA_ACCESS_USER:
         required: false
@@ -108,7 +113,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           image_tag: ${{ needs.push_docker_image.outputs.image_tag }}
-          chart_path: deployments/helm/${{ github.event.repository.name }}
+          chart_path: ${{ inputs.chart_path }}
 
       - name: Finish Deployment
         uses: lockerstock/github-actions/deployment-status@main


### PR DESCRIPTION
# Overview
After remembering that [traefik-middleware](https://github.com/lockerstock/traefik-middleware) exists, I realized that it was far behind on migrations to both the new `github-actions` repository name as well as the reusable `workflow_call` actions. This PR makes some small changes that update usage to accommodate specialty deployments like traefik-middleware.

### Related to:
- https://github.com/lockerstock/traefik-middleware/pull/4