### PR TITLE
Add input flags to repository-cleanup workflow_call

### DIFF
--- a/.github/workflows/reusable-cleanup-repository.yaml
+++ b/.github/workflows/reusable-cleanup-repository.yaml
@@ -3,14 +3,21 @@ name: Cleanup Repository Resources
 on:
   workflow_call:
     inputs:
+      skip_deployment_cleanup:
+        description: Boolean flag to skip the deployment-cleanup job. Should be used if the repository does not create deployments.
+        type: boolean
+        required: false
+        default: false
+
       skip_ghcr_cleanup:
-        description: Boolean flag to skip the ghcr-cleanup job. Should be used if the repository doesn't publish a package.
+        description: Boolean flag to skip the ghcr-cleanup job. Should be used if the repository does not publish a package.
         type: boolean
         required: false
         default: false
 
 jobs:
   deployment-cleanup:
+    if: ${{ !inputs.skip_deployment_cleanup }}
     runs-on: ubuntu-latest
     name: Cleanup Inactive Deployments
 

--- a/.github/workflows/reusable-cleanup-repository.yaml
+++ b/.github/workflows/reusable-cleanup-repository.yaml
@@ -2,6 +2,12 @@ name: Cleanup Repository Resources
 
 on:
   workflow_call:
+    inputs:
+      skip_ghcr_cleanup:
+        description: Boolean flag to skip the ghcr-cleanup job. Should be used if the repository doesn't publish a package.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   deployment-cleanup:
@@ -22,6 +28,7 @@ jobs:
           environment: ${{ matrix.environment }}
 
   ghcr-cleanup:
+    if: ${{ !inputs.skip_ghcr_cleanup }}
     runs-on: ubuntu-latest
     name: Cleanup GitHub Container Registry
 


### PR DESCRIPTION
# Overview
Adds `skip_deployment_cleanup` and `skip_ghcr_cleanup` to [reusable-cleanup-repository.yaml](https://github.com/lockerstock/github-actions/compare/feature/add-skip_ghcr_cleanup-input?expand=1#diff-e49529707ce6cad2822b64cbc6dd2d1135618026a6d149208344f57bc56fe3b0) so instances of it can optionally skip parts of the cleanup process.