### PR TITLE
Remove Helm Chart Package Upload Steps in deploy-helm

### DIFF
--- a/deploy-helm/action.yaml
+++ b/deploy-helm/action.yaml
@@ -197,25 +197,12 @@ runs:
       if: github.ref_type == 'tag' && steps.chart.outputs.source == ''
       run: helm template ${{ steps.repository.outputs.variable }} ${{ inputs.chart_path }} > ${{ steps.repository.outputs.variable }}-${{ steps.version.outputs.variable }}.yaml
       shell: bash
-      
+
     - name: Add template to release
       if: github.ref_type == 'tag'
       run: gh release upload ${{ github.ref_name }} ${{ steps.repository.outputs.variable }}-${{ steps.version.outputs.variable }}.yaml --clobber
       env:
         GH_TOKEN: ${{ inputs.token }}
-      shell: bash
-
-    - name: Build Package
-      if: github.ref_type == 'tag' && steps.chart.outputs.source != ''
-      run: helm package oci://${{ steps.chart.outputs.source }}
-      shell: bash
-
-    - name: Add packaged chart to release
-      if: github.ref_type == 'tag' && steps.chart.outputs.source != ''
-      run: gh release upload ${{ github.ref_name }} "${CHART_PATH##*/}-${{ steps.package.outputs.version }}.tgz" --clobber
-      env:
-        GH_TOKEN: ${{ inputs.token }}
-        CHART_PATH: ${{ steps.chart.outputs.source }}
       shell: bash
 
     - name: Add prepared values.yaml to release


### PR DESCRIPTION
# Overview
The package upload process failed [here](https://github.com/lockerstock/lockerstock-landing/actions/runs/4660736137/jobs/8400482635) because it cannot package from a remote repository. This made me reflect on whether or not this step is even required. Since the package is already available from helm-charts, I felt like this was a no.

From here, I think it would be worthwhile to add an input to `get-package-version` for a timestamp and only match relative semvers if they were created prior to the provided timestamp.