### PR TITLE
Refactor cleanup-deleted-branch action

### DIFF
--- a/cleanup-deleted-branch/action.yaml
+++ b/cleanup-deleted-branch/action.yaml
@@ -47,13 +47,13 @@ runs:
       run: kubectl label namespace ${{ steps.namespace.outputs.name }} ${{ github.repository }}-
       shell: bash
 
-    - name: Get Helm Secrets
+    - name: Get Helm Deploys
       if: steps.namespace.outputs.exists == 'true'
-      id: secrets
-      run: ${{ github.action_path }}/scripts/has_helm_secrets.sh "${{ steps.namespace.outputs.name }}" exists
+      id: deploys
+      run: ${{ github.action_path }}/scripts/has_helm_deploys.sh "${{ steps.namespace.outputs.name }}" exists
       shell: bash
 
     - name: Delete Namespace
-      if: steps.namespace.outputs.exists == 'true' && steps.secrets.outputs.exists != 'true'
+      if: steps.namespace.outputs.exists == 'true' && steps.deploys.outputs.exists != 'true'
       run: kubectl delete namespace "${{ steps.namespace.outputs.name }}"
       shell: bash

--- a/cleanup-deleted-branch/scripts/has_helm_deploys.sh
+++ b/cleanup-deleted-branch/scripts/has_helm_deploys.sh
@@ -5,7 +5,7 @@ VAR_NAME=$2
 
 OUTPUT="false"
 
-if [[ $(kubectl get secrets --namespace $NAMESPACE -o name | grep sh.helm.release) ]]; then
+if [[ $(helm list --namespace $NAMESPACE --no-headers) ]]; then
     OUTPUT="true"
 fi
 

--- a/delete-inactive-deployments/package.json
+++ b/delete-inactive-deployments/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "typescript-action",
+  "name": "delete-inactive-deployments",
   "version": "0.0.0",
   "private": true,
-  "description": "TypeScript template action",
+  "description": "Deletes all inactive GitHub deployments from a given environment.",
   "main": "src/main.ts",
   "scripts": {
     "execute": "ts-node src/main.ts",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/typescript-action.git"
+    "url": "https://github.com/lockerstock/github-actions/tree/main/delete-inactive-deployments"
   },
   "keywords": [
     "actions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
       "license": "MIT"
     },
     "delete-inactive-deployments": {
-      "name": "typescript-action",
       "version": "0.0.0",
       "license": "MIT"
     },
@@ -2094,6 +2093,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/delete-inactive-deployments": {
+      "resolved": "delete-inactive-deployments",
+      "link": true
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
@@ -5749,10 +5752,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/typescript-action": {
-      "resolved": "delete-inactive-deployments",
-      "link": true
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -7553,6 +7552,9 @@
           "dev": true
         }
       }
+    },
+    "delete-inactive-deployments": {
+      "version": "file:delete-inactive-deployments"
     },
     "deprecation": {
       "version": "2.3.1",
@@ -10139,9 +10141,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
-    },
-    "typescript-action": {
-      "version": "file:delete-inactive-deployments"
     },
     "unbox-primitive": {
       "version": "1.0.2",


### PR DESCRIPTION
# Overview
The old way of checking for installed Helm charts queried kubectl for secrets that match the Helm syntax. This was not a good way of doing this. Using `helm list` will list all current releases for a given namespace. This is much more surefire for what I was trying to accomplish.