### PR TITLE
Add "Failed Deployment" step to Docker Build job

### DIFF
--- a/.github/workflows/reusable-helm-deploy.yaml
+++ b/.github/workflows/reusable-helm-deploy.yaml
@@ -89,6 +89,15 @@ jobs:
             BUF_USER=${{ secrets.BUF_USER }}
             BUF_TOKEN=${{ secrets.BUF_TOKEN }}
 
+      - name: Failed Deployment
+        uses: lockerstock/github-actions/deployment-status@main
+        if: failure()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          step: finish
+          environment: ${{ steps.docker.outputs.environment }}
+
   deploy:
     name: Deploy Helm Chart
     runs-on:


### PR DESCRIPTION
# Overview
Added Failed Deployments step to Docker build job for rare cases where the Docker image fails to build. This will set the status of the current deployment to failure instead of leaving it as perpetually pending. 