### PR TITLE
Remove unused secrets from workflow_calls

### DIFF
--- a/.github/workflows/reusable-helm-deploy.yaml
+++ b/.github/workflows/reusable-helm-deploy.yaml
@@ -20,9 +20,6 @@ on:
       GHA_ACCESS_TOKEN:
         required: false
         description: 'Required for Golang services to download private Go modules during Docker image builds.'
-      BUF_USER:
-        required: false
-        description: 'Required for Golang services to access private Buf registries during Docker image builds.'
       BUF_TOKEN:
         required: false
         description: 'Required for Golang and frontend services to access private Buf registries during Docker image builds.'
@@ -84,9 +81,7 @@ jobs:
             "org.opencontainers.image.sha=${{ github.sha }}"
           build-args: |
             RELEASE_VERSION=${{ steps.docker.outputs.image_tag }}
-            ACTOR=${{ secrets.GHA_ACCESS_USER }}
             ACCESS_TOKEN=${{ secrets.GHA_ACCESS_TOKEN }}
-            BUF_USER=${{ secrets.BUF_USER }}
             BUF_TOKEN=${{ secrets.BUF_TOKEN }}
 
       - name: Failed Deployment

--- a/.github/workflows/reusable-verify-go-microservice.yaml
+++ b/.github/workflows/reusable-verify-go-microservice.yaml
@@ -77,7 +77,9 @@ jobs:
           go-version: ${{ inputs.go-version }}
 
       - name: Setup Private Modules
-        run: git config --global url."https://${{ secrets.GHA_ACCESS_USER }}:${{ secrets.GHA_ACCESS_TOKEN }}@github.com".insteadOf "https://github.com"
+        run: |
+          go env -w GOPRIVATE=github.com/${{ github.repository_owner }}/*
+          git config --global url."https://${ACCESS_TOKEN}:x-oauth-basic@github.com".insteadOf "https://github.com"
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/reusable-verify-go-microservice.yaml
+++ b/.github/workflows/reusable-verify-go-microservice.yaml
@@ -12,8 +12,6 @@ on:
         required: true
       GHA_ACCESS_TOKEN:
         required: true
-      BUF_USER:
-        required: true
       BUF_TOKEN:
         required: true
 


### PR DESCRIPTION
# Overview
Through some refactoring with Dockerfiles and new insight into private Go modules, I have found that some of the secrets being required by workflow_calls made available are no longer required or needed. 

## Related to:
- https://github.com/lockerstock/organizations-api/pull/35