### PR TITLE
New Action: Require Changelog Entry

### DIFF
--- a/.github/workflows/test-require-changelog-entry.yaml
+++ b/.github/workflows/test-require-changelog-entry.yaml
@@ -41,15 +41,16 @@ jobs:
         env:
           OUTPUTS: ${{ toJSON(steps.no_changes_changelog.outputs) }}
 
-      - name: Run on no-versions-changelog.md
-        id: no_versions_changelog
-        uses: ./require-changelog-entry
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag_prefix: require-changelog-entry@
-          changelog_path: require-changelog-entry/docs/no-versions-changelog.md
+      # This causes the workflow to error because a CHANGELOG with no base entry is not valid.
+      # - name: Run on no-versions-changelog.md
+      #   id: no_versions_changelog
+      #   uses: ./require-changelog-entry
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     tag_prefix: require-changelog-entry@
+      #     changelog_path: require-changelog-entry/docs/no-versions-changelog.md
 
-      - name: Print no-versions-changelog.md Outputs
-        run: echo "$OUTPUTS"
-        env:
-          OUTPUTS: ${{ toJSON(steps.no_versions_changelog.outputs) }}
+      # - name: Print no-versions-changelog.md Outputs
+      #   run: echo "$OUTPUTS"
+      #   env:
+      #     OUTPUTS: ${{ toJSON(steps.no_versions_changelog.outputs) }}

--- a/.github/workflows/test-require-changelog-entry.yaml
+++ b/.github/workflows/test-require-changelog-entry.yaml
@@ -1,0 +1,55 @@
+name: Test require-changelog-entry
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'require-changelog-entry/**/*'
+      - '.github/workflows/test-require-changelog-entry.yaml'
+
+jobs:
+  test-require-changelog-entry:
+    name: Test require changelog entry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run on CHANGELOG.md
+        id: changelog
+        uses: ./require-changelog-entry
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: require-changelog-entry@
+          changelog_path: require-changelog-entry/docs/CHANGELOG.md
+
+      - name: Print CHANGELOG.md Outputs
+        run: echo "$OUTPUTS"
+        env:
+          OUTPUTS: ${{ toJSON(steps.changelog.outputs) }}
+
+      - name: Run on no-changes-changelog.md
+        id: no_changes_changelog
+        uses: ./require-changelog-entry
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: require-changelog-entry@
+          changelog_path: require-changelog-entry/docs/no-changes-changelog.md
+
+      - name: Print no-changes-changelog.md Outputs
+        run: echo "$OUTPUTS"
+        env:
+          OUTPUTS: ${{ toJSON(steps.no_changes_changelog.outputs) }}
+
+      - name: Run on no-versions-changelog.md
+        id: no_versions_changelog
+        uses: ./require-changelog-entry
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: require-changelog-entry@
+          changelog_path: require-changelog-entry/docs/no-versions-changelog.md
+
+      - name: Print no-versions-changelog.md Outputs
+        run: echo "$OUTPUTS"
+        env:
+          OUTPUTS: ${{ toJSON(steps.no_versions_changelog.outputs) }}

--- a/deploy-helm/charts/repo-example/Chart.yaml
+++ b/deploy-helm/charts/repo-example/Chart.yaml
@@ -3,10 +3,10 @@ name: repo-example
 description: A Helm chart for Kubernetes
 
 annotations:
-  # The following "repository" and "chart" annotations determine the centralized, remote Helm repository to pull the chart from. 
+  # The following "repository" and "chart" annotations determine the centralized, remote Helm repository to pull the chart from.
   # The values.yaml co-located with this file will be supplied into the source Helm repository.
   repository: 'https://helm.lockerstock.io'
-  chart: 'base-nginx'
+  chart: 'microservice'
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/deploy-helm/charts/repo-example/values.yaml
+++ b/deploy-helm/charts/repo-example/values.yaml
@@ -11,7 +11,3 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ''
-
-ingressRoute:
-  enabled: true
-  hostname: '$HOSTNAME'

--- a/require-changelog-entry/README.md
+++ b/require-changelog-entry/README.md
@@ -55,6 +55,7 @@ jobs:
 | - | - |
 | has_changed | Boolean output indicating whether the CHANGELOG file has changed |
 | has_new_version | Boolean output indicating whether a new, untagged version was found in the CHANGELOG |
+| changelog_version_exists | Boolean flag indicating whether the latest CHANGELOG version exists as a git tag. |
 | has_unreleased | Boolean output indicating whether the "Unreleased" section of the CHANGELOG has changed |
 | changelog_latest_version | Latest as-is CHANGELOG version entry. |
 | prepared_latest_version | Latest prefix/suffix prepared CHANGELOG version entry. |

--- a/require-changelog-entry/README.md
+++ b/require-changelog-entry/README.md
@@ -1,52 +1,75 @@
 <!-- action-docs-description -->
-
 ## Description
 
 Checks the CHANGELOG for either new version entry or an updated entry to the "Unreleased" section.
+
 
 <!-- action-docs-description -->
 
 ## Example Usage
 
 ```yaml
+name: Require Changelog Entry
+on:
+  - pull_request
 
+jobs:
+  require-changelog-entry:
+    name: Require Changelog Entry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require Changelog Entry
+        id: changelog
+        uses: lockerstock/github-actions/require-changelog-entry@main
+        with:
+          token: ${{ secret.GITHUB_TOKEN }}
+          changelog_path: CHANGELOG.md
+
+      - name: 'Error if no Changelog entry'
+        if: steps.changelog.outputs.has_new_version == 'false' && steps.changelog.outputs.has_unreleased == 'false'
+        run: |
+          echo "::error file=CHANGELOG.md::No Changelog entry created."
+          error 1
 ```
 
 <!-- action-docs-inputs -->
-
 ## Inputs
 
-| parameter      | description                                                             | required | default                                       |
-| -------------- | ----------------------------------------------------------------------- | -------- | --------------------------------------------- |
-| token          | GITHUB_TOKEN to access the GitHub API if the repository is private      | `false`  |                                               |
-| default_branch | Default branch to compare the "Unreleased" section of the CHANGELOG to. | `false`  | ${{ github.event.repository.default_branch }} |
-| tag_prefix     | Optional prefix string to apply to tag search                           | `false`  |                                               |
-| tag_suffix     | Optional suffix string to apply to tag search                           | `false`  |                                               |
-| changelog_path | Path to CHANGELOG file within repository                                | `false`  | CHANGELOG.md                                  |
+| parameter | description | required | default |
+| - | - | - | - |
+| token | GITHUB_TOKEN to access the GitHub API if the repository is private | `false` |  |
+| default_branch | Default branch to compare the "Unreleased" section of the CHANGELOG to. | `false` | ${{ github.event.repository.default_branch }} |
+| tag_prefix | Optional prefix string to apply to tag search | `false` |  |
+| tag_suffix | Optional suffix string to apply to tag search | `false` |  |
+| changelog_path | Path to CHANGELOG file within repository | `false` | CHANGELOG.md |
+
+
 
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
-
 ## Outputs
 
-| parameter                | description                                                                             |
-| ------------------------ | --------------------------------------------------------------------------------------- |
-| has_changed              | Boolean output indicating whether the CHANGELOG file has changed                        |
-| has_new_version          | Boolean output indicating whether a new, untagged version was found in the CHANGELOG    |
-| has_unreleased           | Boolean output indicating whether the "Unreleased" section of the CHANGELOG has changed |
-| changelog_latest_version | Latest as-is CHANGELOG version entry.                                                   |
-| prepared_latest_version  | Latest prefix/suffix prepared CHANGELOG version entry.                                  |
-| latest_version_entry     | The contents of the latest CHANGELOG version entry                                      |
-| current_unreleased_entry | The contents of the current "Unreleased" section in the CHANGELOG                       |
-| default_unreleased_entry | The contents of the default branch "Unreleased" section in the CHANGELOG                |
+| parameter | description |
+| - | - |
+| has_changed | Boolean output indicating whether the CHANGELOG file has changed |
+| has_new_version | Boolean output indicating whether a new, untagged version was found in the CHANGELOG |
+| has_unreleased | Boolean output indicating whether the "Unreleased" section of the CHANGELOG has changed |
+| changelog_latest_version | Latest as-is CHANGELOG version entry. |
+| prepared_latest_version | Latest prefix/suffix prepared CHANGELOG version entry. |
+| latest_version_entry | The contents of the latest CHANGELOG version entry |
+| current_unreleased_entry | The contents of the current "Unreleased" section in the CHANGELOG |
+| default_unreleased_entry | The contents of the default branch "Unreleased" section in the CHANGELOG |
+
+
 
 <!-- action-docs-outputs -->
 
 <!-- action-docs-runs -->
-
 ## Runs
 
 This action is a `composite` action.
+
 
 <!-- action-docs-runs -->

--- a/require-changelog-entry/README.md
+++ b/require-changelog-entry/README.md
@@ -1,13 +1,10 @@
 <!-- action-docs-description -->
-<!-- action-docs-description -->
 
-Logic path:
-- Retrieve latest changelog entry via https://github.com/mindsers/changelog-reader-action (set validation_depth to 1, and leave version blank)
-- Check tags of repo for matching version, if no matching version is found, all is good and return cleanly
-- if matching version is found, this means that this is not a new version
-- Checkout the default branch of the repo and use https://github.com/mindsers/changelog-reader-action to pull the "Unreleased" entry of both
-- If the description is the different, all is good and return cleanly
-- If the description is the same as the default branch version, then no changes have been made and return with an error
+## Description
+
+Checks the CHANGELOG for either new version entry or an updated entry to the "Unreleased" section.
+
+<!-- action-docs-description -->
 
 ## Example Usage
 
@@ -16,10 +13,40 @@ Logic path:
 ```
 
 <!-- action-docs-inputs -->
+
+## Inputs
+
+| parameter      | description                                                             | required | default                                       |
+| -------------- | ----------------------------------------------------------------------- | -------- | --------------------------------------------- |
+| token          | GITHUB_TOKEN to access the GitHub API if the repository is private      | `false`  |                                               |
+| default_branch | Default branch to compare the "Unreleased" section of the CHANGELOG to. | `false`  | ${{ github.event.repository.default_branch }} |
+| tag_prefix     | Optional prefix string to apply to tag search                           | `false`  |                                               |
+| tag_suffix     | Optional suffix string to apply to tag search                           | `false`  |                                               |
+| changelog_path | Path to CHANGELOG file within repository                                | `false`  | CHANGELOG.md                                  |
+
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
+
+## Outputs
+
+| parameter                | description                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| has_changed              | Boolean output indicating whether the CHANGELOG file has changed                        |
+| has_new_version          | Boolean output indicating whether a new, untagged version was found in the CHANGELOG    |
+| has_unreleased           | Boolean output indicating whether the "Unreleased" section of the CHANGELOG has changed |
+| changelog_latest_version | Latest as-is CHANGELOG version entry.                                                   |
+| prepared_latest_version  | Latest prefix/suffix prepared CHANGELOG version entry.                                  |
+| latest_version_entry     | The contents of the latest CHANGELOG version entry                                      |
+| current_unreleased_entry | The contents of the current "Unreleased" section in the CHANGELOG                       |
+| default_unreleased_entry | The contents of the default branch "Unreleased" section in the CHANGELOG                |
+
 <!-- action-docs-outputs -->
 
 <!-- action-docs-runs -->
+
+## Runs
+
+This action is a `composite` action.
+
 <!-- action-docs-runs -->

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -33,7 +33,7 @@ outputs:
 
   has_new_version:
     description: 'Boolean output indicating whether a new, untagged version was found in the CHANGELOG'
-    value: ${{ !steps.tag.outputs.exists }}
+    value: ${{ steps.tag.outputs.exists == 'false' }}
 
   changelog_version_exists:
     description: 'Boolean flag indicating whether the latest CHANGELOG version exists as a git tag.'

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -1,0 +1,138 @@
+name: 'Require Changelog Entry'
+description: 'Checks the CHANGELOG for either new version entry or an updated entry to the "Unreleased" section.'
+
+inputs:
+  token:
+    description: GITHUB_TOKEN to access the GitHub API if the repository is private
+    required: false
+
+  default_branch:
+    description: Default branch to compare the "Unreleased" section of the CHANGELOG to.
+    default: ${{ github.event.repository.default_branch }}
+    required: false
+
+  tag_prefix:
+    description: Optional prefix string to apply to tag search
+    required: false
+    default: ''
+
+  tag_suffix:
+    description: Optional suffix string to apply to tag search
+    required: false
+    default: ''
+
+  changelog_path:
+    description: Path to CHANGELOG file within repository
+    required: false
+    default: 'CHANGELOG.md'
+
+outputs:
+  has_changed:
+    description: 'Boolean output indicating whether the CHANGELOG file has changed'
+    value: ${{ steps.changes.outputs.changelog }}
+
+  has_new_version:
+    description: 'Boolean output indicating whether a new, untagged version was found in the CHANGELOG'
+    value: ${{ !steps.tag.outputs.exists }}
+
+  has_unreleased:
+    description: 'Boolean output indicating whether the "Unreleased" section of the CHANGELOG has changed'
+    value: ${{ steps.unreleased.outputs.changed }}
+
+  changelog_latest_version:
+    description: 'Latest as-is CHANGELOG version entry.'
+    value: ${{ steps.current_latest.outputs.version }}
+
+  prepared_latest_version:
+    description: 'Latest prefix/suffix prepared CHANGELOG version entry.'
+    value: ${{ steps.prepared_latest.outputs.version }}
+
+  latest_version_entry:
+    description: 'The contents of the latest CHANGELOG version entry'
+    value: ${{ steps.current_latest.outputs.changes }}
+
+  current_unreleased_entry:
+    description: 'The contents of the current "Unreleased" section in the CHANGELOG'
+    value: ${{ steps.current_unreleased.outputs.changes }}
+
+  default_unreleased_entry:
+    description: 'The contents of the default branch "Unreleased" section in the CHANGELOG'
+    value: ${{ steps.default_unreleased.outputs.changes }}
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          changelog:
+            - '${{ inputs.changelog_path }}'
+
+    ###### Checkout Repository Refs to action_path ######
+
+    - name: Checkout Repository at current ref
+      uses: actions/checkout@v3
+      with:
+        token: ${{ inputs.token }}
+        path: ${{ github.action_path }}/current
+
+    - name: Checkout Repository at default branch
+      uses: actions/checkout@v3
+      with:
+        token: ${{ inputs.token }}
+        ref: ${{ inputs.default_branch }}
+        path: ${{ github.action_path }}/default
+
+    ###### Retrieve latest and Unreleased entries from CHANGELOGs ######
+
+    - name: Get Current Latest Changelog Entry
+      id: current_latest
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_level: none
+        path: ${{ github.action_path }}/current/${{ inputs.changelog_path }}
+
+    - name: Get Current Unreleased Changelog Entry
+      id: current_unreleased
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_level: none
+        path: ${{ github.action_path }}/current/${{ inputs.changelog_path }}
+        version: Unreleased
+
+    - name: Get Default Unreleased Changelog Entry
+      id: default_unreleased
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_level: none
+        path: ${{ github.action_path }}/default/${{ inputs.changelog_path }}
+        version: Unreleased
+
+    ###### Prepare Latest Tag ######
+
+    - name: Prepare Latest Tag
+      id: prepared_latest
+      run: echo "version=${{ inputs.tag_prefix }}${{ steps.current_latest.outputs.version }}${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    ###### Check for Existing Tag ######
+
+    - name: Check if tag already exists
+      uses: lockerstock/github-actions/git-tag-exists@main
+      id: tag
+      with:
+        token: ${{ inputs.token }}
+        tag: ${{ steps.prepared_latest.outputs.version }}
+
+    ###### Output Unreleased Changes ######
+
+    - name: Check for "Unreleased" Changes
+      id: unreleased
+      run: |
+        if [ "${{ steps.current_unreleased.outputs.changes }}" = "${{ steps.default_unreleased.outputs.changes }}" ]; then
+          echo "changed=false" >> $GITHUB_OUTPUT
+        else
+          echo "changed=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -35,6 +35,10 @@ outputs:
     description: 'Boolean output indicating whether a new, untagged version was found in the CHANGELOG'
     value: ${{ !steps.tag.outputs.exists }}
 
+  changelog_version_exists:
+    description: 'Boolean flag indicating whether the latest CHANGELOG version exists as a git tag.'
+    value: ${{ steps.tag.outputs.exists }}
+
   has_unreleased:
     description: 'Boolean output indicating whether the "Unreleased" section of the CHANGELOG has changed'
     value: ${{ steps.unreleased.outputs.changed }}

--- a/require-changelog-entry/docs/CHANGELOG.md
+++ b/require-changelog-entry/docs/CHANGELOG.md
@@ -14,3 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
+
+## [v0.1.0]
+
+### Added
+
+- Initial Creation

--- a/require-changelog-entry/docs/no-changes-changelog.md
+++ b/require-changelog-entry/docs/no-changes-changelog.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
+## [v0.1.0]
+
+### Added
+
+- Initial Creation

--- a/require-changelog-entry/docs/no-changes-changelog.md
+++ b/require-changelog-entry/docs/no-changes-changelog.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [v0.1.0]
+## [v0.0.0]
 
 ### Added
 

--- a/require-changelog-entry/docs/no-versions-changelog.md
+++ b/require-changelog-entry/docs/no-versions-changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed


### PR DESCRIPTION
# Overview
Created new action that will check provided CHANGELOG for a new, untagged version or new entries within the "Unreleased" section. Will check both and report on both.