### PR TITLE
Changelog Auto Releaser

### DIFF
--- a/.github/workflows/autorelease-require-changelog-entry.yaml
+++ b/.github/workflows/autorelease-require-changelog-entry.yaml
@@ -1,0 +1,31 @@
+name: Auto Release require-changelog-entry
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - require-changelog-entry/docs/CHANGELOG.md
+
+jobs:
+  changelog-autorelease:
+    name: Auto Release from CHANGELOG
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Auto Release from CHANGELOG
+        id: changelog
+        uses: ./autorelease
+        with:
+          token: ${{ secret.GITHUB_TOKEN }}
+          changelog_path: require-changelog-entry/docs/CHANGELOG.md
+          tag_prefix: require-changelog-entry@
+
+      - name: Print auto release Outputs
+        if: always()
+        run: echo "$OUTPUTS"
+        env:
+          OUTPUTS: ${{ toJSON(steps.changelog.outputs) }}

--- a/.github/workflows/test-require-changelog-entry.yaml
+++ b/.github/workflows/test-require-changelog-entry.yaml
@@ -22,6 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_prefix: require-changelog-entry@
           changelog_path: require-changelog-entry/docs/CHANGELOG.md
+          error_on_missing: true
 
       - name: Print CHANGELOG.md Outputs
         run: echo "$OUTPUTS"

--- a/.github/workflows/test-require-changelog-entry.yaml
+++ b/.github/workflows/test-require-changelog-entry.yaml
@@ -25,11 +25,13 @@ jobs:
           error_on_missing: true
 
       - name: Print CHANGELOG.md Outputs
+        if: always()
         run: echo "$OUTPUTS"
         env:
           OUTPUTS: ${{ toJSON(steps.changelog.outputs) }}
 
       - name: Run on no-changes-changelog.md
+        if: always()
         id: no_changes_changelog
         uses: ./require-changelog-entry
         with:
@@ -38,6 +40,7 @@ jobs:
           changelog_path: require-changelog-entry/docs/no-changes-changelog.md
 
       - name: Print no-changes-changelog.md Outputs
+        if: always()
         run: echo "$OUTPUTS"
         env:
           OUTPUTS: ${{ toJSON(steps.no_changes_changelog.outputs) }}

--- a/autoreleaser/README.md
+++ b/autoreleaser/README.md
@@ -14,9 +14,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - CHANGELOG.md
 
 jobs:
-  changelog-autorelease
+  changelog-autorelease:
     name: Auto Release from CHANGELOG
     runs-on: ubuntu-latest
 
@@ -35,10 +37,7 @@ jobs:
 | parameter | description | required | default |
 | - | - | - | - |
 | token | GITHUB_TOKEN to access the GitHub API if the repository is private | `true` |  |
-| tag | Optional tag version to search for in the CHANGELOG. This can be used if prior steps determine which version needs released. 
-If the provided input does not exist in the CHANGELOG, this action will fail.
-If this input is not provided, then the latest entry in the CHANGELOG will be retrieved.
- | `false` |  |
+| tag | Optional tag version to search for in the CHANGELOG. This can be used if prior steps determine which version needs released. If the provided input does not exist in the CHANGELOG, this action will fail. If this input is not provided, then the latest entry in the CHANGELOG will be retrieved. | `false` |  |
 | tag_prefix | Optional prefix string to apply to tag during creation. | `false` |  |
 | tag_suffix | Optional suffix string to apply to tag during creation. | `false` |  |
 | changelog_path | Path to CHANGELOG file within repository | `false` | CHANGELOG.md |

--- a/autoreleaser/README.md
+++ b/autoreleaser/README.md
@@ -1,0 +1,71 @@
+<!-- action-docs-description -->
+## Description
+
+Auto Release action based on new CHANGELOG entry version
+
+
+<!-- action-docs-description -->
+
+## Example Usage
+
+```yaml
+name: Auto Release from CHANGELOG
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  changelog-autorelease
+    name: Auto Release from CHANGELOG
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Auto Release from CHANGELOG
+        id: changelog
+        uses: lockerstock/github-actions/autorelease@main
+        with:
+          token: ${{ secret.GITHUB_TOKEN }}
+          changelog_path: CHANGELOG.md
+```
+
+<!-- action-docs-inputs -->
+## Inputs
+
+| parameter | description | required | default |
+| - | - | - | - |
+| token | GITHUB_TOKEN to access the GitHub API if the repository is private | `true` |  |
+| tag | Optional tag version to search for in the CHANGELOG. This can be used if prior steps determine which version needs released. 
+If the provided input does not exist in the CHANGELOG, this action will fail.
+If this input is not provided, then the latest entry in the CHANGELOG will be retrieved.
+ | `false` |  |
+| tag_prefix | Optional prefix string to apply to tag during creation. | `false` |  |
+| tag_suffix | Optional suffix string to apply to tag during creation. | `false` |  |
+| changelog_path | Path to CHANGELOG file within repository | `false` | CHANGELOG.md |
+| artifacts | An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs). | `false` |  |
+| replace_artifacts | Indicates if existing release artifacts should be replaced. | `false` | true |
+
+
+
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| - | - |
+| changelog_version | Latest as-is CHANGELOG version entry or version matching inputted tag. |
+| prepared_version | Latest prefix/suffix prepared CHANGELOG version entry. |
+| created_release | Boolean flag indicating whether a new tag and release was created. Will be false if the latest version in the CHANGELOG already exists as a tag in the repository. |
+
+
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+
+
+<!-- action-docs-runs -->

--- a/autoreleaser/README.md
+++ b/autoreleaser/README.md
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Auto Release from CHANGELOG
         id: changelog
         uses: lockerstock/github-actions/autorelease@main
@@ -55,7 +58,6 @@ jobs:
 | - | - |
 | changelog_version | Latest as-is CHANGELOG version entry or version matching inputted tag. |
 | prepared_version | Latest prefix/suffix prepared CHANGELOG version entry. |
-| created_release | Boolean flag indicating whether a new tag and release was created. Will be false if the latest version in the CHANGELOG already exists as a tag in the repository. |
 
 
 

--- a/autoreleaser/action.yaml
+++ b/autoreleaser/action.yaml
@@ -7,10 +7,7 @@ inputs:
     required: true
 
   tag:
-    description: |
-      Optional tag version to search for in the CHANGELOG. This can be used if prior steps determine which version needs released. 
-      If the provided input does not exist in the CHANGELOG, this action will fail.
-      If this input is not provided, then the latest entry in the CHANGELOG will be retrieved.
+    description: Optional tag version to search for in the CHANGELOG. This can be used if prior steps determine which version needs released. If the provided input does not exist in the CHANGELOG, this action will fail. If this input is not provided, then the latest entry in the CHANGELOG will be retrieved.
     required: false
     default: ''
 

--- a/autoreleaser/action.yaml
+++ b/autoreleaser/action.yaml
@@ -1,0 +1,101 @@
+name: Changelog Auto Releaser
+description: Auto Release action based on new CHANGELOG entry version
+
+inputs:
+  token:
+    description: GITHUB_TOKEN to access the GitHub API if the repository is private
+    required: true
+
+  tag:
+    description: |
+      Optional tag version to search for in the CHANGELOG. This can be used if prior steps determine which version needs released. 
+      If the provided input does not exist in the CHANGELOG, this action will fail.
+      If this input is not provided, then the latest entry in the CHANGELOG will be retrieved.
+    required: false
+    default: ''
+
+  tag_prefix:
+    description: Optional prefix string to apply to tag during creation.
+    required: false
+    default: ''
+
+  tag_suffix:
+    description: Optional suffix string to apply to tag during creation.
+    required: false
+    default: ''
+
+  changelog_path:
+    description: Path to CHANGELOG file within repository
+    required: false
+    default: 'CHANGELOG.md'
+
+  artifacts:
+    description: An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs).
+    required: false
+
+  replace_artifacts:
+    description: Indicates if existing release artifacts should be replaced.
+    required: false
+    default: 'true'
+
+outputs:
+  changelog_version:
+    description: 'Latest as-is CHANGELOG version entry or version matching inputted tag.'
+    value: ${{ steps.current_latest.outputs.version }}
+
+  prepared_version:
+    description: 'Latest prefix/suffix prepared CHANGELOG version entry.'
+    value: ${{ steps.prepared.outputs.version }}
+
+  created_release:
+    description: 'Boolean flag indicating whether a new tag and release was created. Will be false if the latest version in the CHANGELOG already exists as a tag in the repository.'
+    value: false'
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Get Changelog Entry
+      id: changelog_reader
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        validation_level: none
+        path: ${{ inputs.changelog_path }}
+        version: ${{ inputs.tag }}
+
+    - name: Prepare Tag
+      id: prepared
+      run: echo "version=${{ inputs.tag_prefix }}${{ steps.changelog_reader.outputs.version }}${{ inputs.tag_suffix }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Check if tag already exists
+      uses: lockerstock/github-actions/git-tag-exists@main
+      id: tag
+      with:
+        token: ${{ inputs.token }}
+        tag: ${{ steps.prepared.outputs.version }}
+
+    - name: Create Tag
+      id: tag_version
+      if: steps.tag.outputs.exists == 'false'
+      uses: mathieudutour/github-tag-action@v6.1
+      with:
+        github_token: ${{ inputs.token }}
+        custom_tag: ${{ steps.prepared.outputs.version }}
+        release_branches: ${{ github.event.repository.name }}
+        tag_prefix: ''
+
+    - name: Create a GitHub release
+      if: steps.tag.outputs.exists == 'false'
+      uses: ncipollo/release-action@v1
+      with:
+        token: ${{ inputs.token }}
+        tag: ${{ steps.prepared.outputs.version }}
+        name: ${{ steps.prepared.outputs.version }}
+        body: ${{ steps.changelog_reader.outputs.changes }}
+        artifacts: ${{ inputs.artifacts }}
+        replacesArtifacts: ${{ inputs.replace_artifacts }}
+        prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
+        draft: false

--- a/autoreleaser/action.yaml
+++ b/autoreleaser/action.yaml
@@ -38,22 +38,15 @@ inputs:
 outputs:
   changelog_version:
     description: 'Latest as-is CHANGELOG version entry or version matching inputted tag.'
-    value: ${{ steps.current_latest.outputs.version }}
+    value: ${{ steps.changelog_reader.outputs.version }}
 
   prepared_version:
     description: 'Latest prefix/suffix prepared CHANGELOG version entry.'
     value: ${{ steps.prepared.outputs.version }}
 
-  created_release:
-    description: 'Boolean flag indicating whether a new tag and release was created. Will be false if the latest version in the CHANGELOG already exists as a tag in the repository.'
-    value: false'
-
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
     - name: Get Changelog Entry
       id: changelog_reader
       uses: mindsers/changelog-reader-action@v2

--- a/require-changelog-entry/README.md
+++ b/require-changelog-entry/README.md
@@ -38,11 +38,13 @@ jobs:
 
 | parameter | description | required | default |
 | - | - | - | - |
-| token | GITHUB_TOKEN to access the GitHub API if the repository is private | `false` |  |
+| token | GITHUB_TOKEN to access the GitHub API if the repository is private | `true` |  |
 | default_branch | Default branch to compare the "Unreleased" section of the CHANGELOG to. | `false` | ${{ github.event.repository.default_branch }} |
 | tag_prefix | Optional prefix string to apply to tag search | `false` |  |
 | tag_suffix | Optional suffix string to apply to tag search | `false` |  |
 | changelog_path | Path to CHANGELOG file within repository | `false` | CHANGELOG.md |
+| error_on_missing | Boolean flag to have this action terminate with error when a new version and new Unreleased entry are not found. | `false` | false |
+| error_message | Error message to print when a new version and new Unreleased entry are not found. Will be applied as an error to the given CHANGELOG path. | `false` | It is required via GitHub Action workflow that this CHANGELOG has a new version or new Unreleased entry. |
 
 
 

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -163,7 +163,7 @@ runs:
       run: |
         echo "::error file=${{ inputs.changelog_path }}::${{ inputs.error_message }}"
 
-        if [ "${{ inputs.error_on_missing == 'true' }}" ]; then
+        if [ "${{ inputs.error_on_missing }}" = true ]; then
           exit 1
         fi
       shell: bash

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -4,7 +4,7 @@ description: 'Checks the CHANGELOG for either new version entry or an updated en
 inputs:
   token:
     description: GITHUB_TOKEN to access the GitHub API if the repository is private
-    required: false
+    required: true
 
   default_branch:
     description: Default branch to compare the "Unreleased" section of the CHANGELOG to.
@@ -26,6 +26,16 @@ inputs:
     required: false
     default: 'CHANGELOG.md'
 
+  error_on_missing:
+    description: Boolean flag to have this action terminate with error when a new version and new Unreleased entry are not found.
+    required: false
+    default: 'false'
+
+  error_message:
+    description: Error message to print when a new version and new Unreleased entry are not found. Will be applied as an error to the given CHANGELOG path.
+    required: false
+    default: 'It is required via GitHub Action workflow that this CHANGELOG has a new version or new Unreleased entry.'
+
 outputs:
   has_changed:
     description: 'Boolean output indicating whether the CHANGELOG file has changed'
@@ -33,7 +43,7 @@ outputs:
 
   has_new_version:
     description: 'Boolean output indicating whether a new, untagged version was found in the CHANGELOG'
-    value: ${{ steps.tag.outputs.exists == 'false' }}
+    value: ${{ steps.new_version.outputs.has_new_version }}
 
   changelog_version_exists:
     description: 'Boolean flag indicating whether the latest CHANGELOG version exists as a git tag.'
@@ -138,5 +148,22 @@ runs:
           echo "changed=false" >> $GITHUB_OUTPUT
         else
           echo "changed=true" >> $GITHUB_OUTPUT
+        fi
+      shell: bash
+
+    - name: Check for new version
+      id: new_version
+      run: echo "has_new_version=${{ steps.tag.outputs.exists == 'false' }}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    ###### Error on missing new entries ######
+
+    - name: Error on Missing New entries
+      if: steps.new_version.outputs.has_new_version == 'false' && steps.unreleased.outputs.changed == 'false'
+      run: |
+        echo "::error file=${{ inputs.changelog_path }}::${{ inputs.error_message }}"
+
+        if [ "${{ inputs.error_on_missing == 'true' }}" ]; then
+          exit 1
         fi
       shell: bash

--- a/require-changelog-entry/docs/CHANGELOG.md
+++ b/require-changelog-entry/docs/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [v0.2.0]
+
+### Added
+
+- Optional exit with error state on no new CHANGELOG entries
+- Append customizable error message to CHANGELOG file when no new entries
+
 ## [v0.1.0]
 
 ### Added


### PR DESCRIPTION
# Overview
New Action to perform auto-releases based on new version entries in the CHANGELOG. This composite action works by locating the latest or provided version within the CHANGELOG, checks to see if a matching git tags exists, and if not creates a new tag and GitHub release with the notes from the CHANGELOG version entry.

Also updated the `require-changelog-entry` action to include an optional input that will exit with an error to fail a workflow when a new version or unreleased entry is not found.