### PR TITLE
Fix require-changelog-entry temporary checkout steps

### DIFF
--- a/autoreleaser/README.md
+++ b/autoreleaser/README.md
@@ -30,7 +30,7 @@ jobs:
         id: changelog
         uses: lockerstock/github-actions/autoreleaser@main
         with:
-          token: ${{ secret.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           changelog_path: CHANGELOG.md
 ```
 

--- a/require-changelog-entry/README.md
+++ b/require-changelog-entry/README.md
@@ -23,7 +23,7 @@ jobs:
         id: changelog
         uses: lockerstock/github-actions/require-changelog-entry@main
         with:
-          token: ${{ secret.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           changelog_path: CHANGELOG.md
 
       - name: 'Error if no Changelog entry'
@@ -40,6 +40,7 @@ jobs:
 | - | - | - | - |
 | token | GITHUB_TOKEN to access the GitHub API if the repository is private | `true` |  |
 | default_branch | Default branch to compare the "Unreleased" section of the CHANGELOG to. | `false` | ${{ github.event.repository.default_branch }} |
+| checkout_path | This action checks out the repository for the current SHA as well as from the default branch. This path indicates where to checkout the repositories as to not clash with any other work in the workflow. | `false` | temp/require-changelog-entry |
 | tag_prefix | Optional prefix string to apply to tag search | `false` |  |
 | tag_suffix | Optional suffix string to apply to tag search | `false` |  |
 | changelog_path | Path to CHANGELOG file within repository | `false` | CHANGELOG.md |

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -94,14 +94,14 @@ runs:
       uses: actions/checkout@v3
       with:
         token: ${{ inputs.token }}
-        path: ${{ input.checkout_path }}/current
+        path: ${{ inputs.checkout_path }}/current
 
     - name: Checkout Repository at default branch
       uses: actions/checkout@v3
       with:
         token: ${{ inputs.token }}
         ref: ${{ inputs.default_branch }}
-        path: ${{ input.checkout_path }}/default
+        path: ${{ inputs.checkout_path }}/default
 
     ###### Retrieve latest and Unreleased entries from CHANGELOGs ######
 
@@ -110,14 +110,14 @@ runs:
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: none
-        path: ${{ input.checkout_path }}/current/${{ inputs.changelog_path }}
+        path: ${{ inputs.checkout_path }}/current/${{ inputs.changelog_path }}
 
     - name: Get Current Unreleased Changelog Entry
       id: current_unreleased
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: none
-        path: ${{ input.checkout_path }}/current/${{ inputs.changelog_path }}
+        path: ${{ inputs.checkout_path }}/current/${{ inputs.changelog_path }}
         version: Unreleased
 
     - name: Get Default Unreleased Changelog Entry
@@ -125,7 +125,7 @@ runs:
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: none
-        path: ${{ input.checkout_path }}/default/${{ inputs.changelog_path }}
+        path: ${{ inputs.checkout_path }}/default/${{ inputs.changelog_path }}
         version: Unreleased
 
     ###### Prepare Latest Tag ######

--- a/require-changelog-entry/action.yaml
+++ b/require-changelog-entry/action.yaml
@@ -11,6 +11,11 @@ inputs:
     default: ${{ github.event.repository.default_branch }}
     required: false
 
+  checkout_path:
+    description: This action checks out the repository for the current SHA as well as from the default branch. This path indicates where to checkout the repositories as to not clash with any other work in the workflow.
+    default: temp/require-changelog-entry
+    required: false
+
   tag_prefix:
     description: Optional prefix string to apply to tag search
     required: false
@@ -89,14 +94,14 @@ runs:
       uses: actions/checkout@v3
       with:
         token: ${{ inputs.token }}
-        path: ${{ github.action_path }}/current
+        path: ${{ input.checkout_path }}/current
 
     - name: Checkout Repository at default branch
       uses: actions/checkout@v3
       with:
         token: ${{ inputs.token }}
         ref: ${{ inputs.default_branch }}
-        path: ${{ github.action_path }}/default
+        path: ${{ input.checkout_path }}/default
 
     ###### Retrieve latest and Unreleased entries from CHANGELOGs ######
 
@@ -105,14 +110,14 @@ runs:
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: none
-        path: ${{ github.action_path }}/current/${{ inputs.changelog_path }}
+        path: ${{ input.checkout_path }}/current/${{ inputs.changelog_path }}
 
     - name: Get Current Unreleased Changelog Entry
       id: current_unreleased
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: none
-        path: ${{ github.action_path }}/current/${{ inputs.changelog_path }}
+        path: ${{ input.checkout_path }}/current/${{ inputs.changelog_path }}
         version: Unreleased
 
     - name: Get Default Unreleased Changelog Entry
@@ -120,7 +125,7 @@ runs:
       uses: mindsers/changelog-reader-action@v2
       with:
         validation_level: none
-        path: ${{ github.action_path }}/default/${{ inputs.changelog_path }}
+        path: ${{ input.checkout_path }}/default/${{ inputs.changelog_path }}
         version: Unreleased
 
     ###### Prepare Latest Tag ######

--- a/require-changelog-entry/docs/CHANGELOG.md
+++ b/require-changelog-entry/docs/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [v0.2.1]
+
+### Fixed
+
+- Invalid checkout process on `${{ github.action_path }}` path.
+
 ## [v0.2.0]
 
 ### Added


### PR DESCRIPTION
# Overview
Thanks to this [run](https://github.com/lockerstock/helm-charts/actions/runs/4908745029/jobs/8764701961) it was made apparent that it is not allowed to checkout code into the `${{ github.action_path }}` location. The new `checkout_path` input provides a means to both checkout into a viable location as well as allow consumers to customize the path in case it has crossover.