### PR TITLE
Auto-release Reusable Workflow Call

### DIFF
--- a/.github/workflows/reusable-changelog.yaml
+++ b/.github/workflows/reusable-changelog.yaml
@@ -28,9 +28,6 @@ jobs:
 
     if: github.event_name == 'pull_request'
 
-    permissions:
-      contents: read
-
     steps:
       - name: Require Changelog Entry
         id: changelog

--- a/.github/workflows/reusable-changelog.yaml
+++ b/.github/workflows/reusable-changelog.yaml
@@ -1,0 +1,65 @@
+name: Changelog Auto-releaser
+
+on:
+  workflow_call:
+    inputs:
+      changelog_path:
+        default: CHANGELOG.md
+        required: false
+        type: string
+        description: 'Path to CHANGELOG'
+
+      tag_prefix:
+        default: ''
+        required: false
+        type: string
+        description: 'Optional prefix string to apply to tag during creation.'
+
+      tag_suffix:
+        default: ''
+        required: false
+        type: string
+        description: 'Optional suffix string to apply to tag during creation.'
+
+jobs:
+  require_changelog_entry:
+    name: Require Changelog Entry
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'pull_request'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Require Changelog Entry
+        id: changelog
+        uses: lockerstock/github-actions/require-changelog-entry@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          changelog_path: ${{ inputs.changelog_path }}
+          error_on_missing: true
+          tag_prefix: ${{ inputs.tag_prefix }}
+          tag_suffix: ${{ inputs.tag_suffix }}
+
+  changelog_auto_release:
+    name: Auto Release Changelog Entry
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Auto Release from CHANGELOG
+        id: changelog
+        uses: lockerstock/github-actions/autoreleaser@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          changelog_path: ${{ inputs.changelog_path }}
+          tag_prefix: ${{ inputs.tag_prefix }}
+          tag_suffix: ${{ inputs.tag_suffix }}

--- a/deploy-helm/action.yaml
+++ b/deploy-helm/action.yaml
@@ -233,3 +233,23 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
       working-directory: ${{ inputs.chart_path }}
       shell: bash
+
+    - name: Added Deployment Instructions for Helm Repository
+      uses: lockerstock/github-actions/add-release-notes@main
+      if: github.ref_type == 'tag' && steps.chart.outputs.has_repo == 'true'
+      with:
+        token: ${{ inputs.token }}
+        title: helm-repository-deployment-instructions
+        body: |
+          ## Deployment Instructions
+
+          Download the [values.yaml](${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}/values.yaml) file to your local machine in the current working directory of your terminal.
+
+          ### Upgrade/install Helm chart
+
+          ```shell
+          helm upgrade --install ${{ github.event.repository.name }} ${{ github.repository_owner }}/${{ steps.chart.outputs.chart }}
+            --version ${{ steps.repo_version.outputs.version }} \
+            -f values.yaml \
+            --namespace production
+          ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Workflow Call Examples
+
+The `.yaml` files co-located in this directory are contain example workflows that can be added as-is to relevant microservices to perform CI/CD actions.

--- a/examples/changelog.yaml
+++ b/examples/changelog.yaml
@@ -1,0 +1,17 @@
+name: Changelog Auto-releaser
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+# Kill the workflow if the PR is updated with a new commit. Pushes to main will run sequentially.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  call-changelog-workflow:
+    name: Changelog Auto-releaser
+    uses: lockerstock/github-actions/.github/workflows/reusable-changelog.yaml@main

--- a/examples/cleanup.yaml
+++ b/examples/cleanup.yaml
@@ -1,0 +1,11 @@
+name: Cleanup Repository Resources
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 15 6 5 * * # 6:15AM UTC on 5th day of every month (1:15AM CDT/12:15AM CST)
+
+jobs:
+  call-cleanup-repository-workflow:
+    name: Cleanup Repository Resources
+    uses: lockerstock/github-actions/.github/workflows/reusable-cleanup-repository.yaml@main

--- a/examples/delete.yaml
+++ b/examples/delete.yaml
@@ -1,0 +1,8 @@
+name: Cleanup Deleted Branch
+on:
+  - delete
+
+jobs:
+  call-cleanup-deleted-branch-workflow:
+    name: Cleanup Deleted Branch
+    uses: lockerstock/github-actions/.github/workflows/reusable-cleanup-deleted-branch.yaml@main

--- a/examples/helm-deploy.yaml
+++ b/examples/helm-deploy.yaml
@@ -1,0 +1,22 @@
+name: Deploy Application
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+  workflow_dispatch:
+
+# Kill the workflow if the PR is updated with a new commit. Pushes to main will run sequentially.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  call-helm-deploy-workflow:
+    name: Build and Deploy Application
+    uses: lockerstock/github-actions/.github/workflows/reusable-helm-deploy.yaml@main
+    secrets:
+      GHA_ACCESS_TOKEN: ${{ secrets.GHA_ACCESS_TOKEN }}

--- a/examples/push-buf.yaml
+++ b/examples/push-buf.yaml
@@ -1,0 +1,13 @@
+name: Push Buf Resources
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  call-push-buf-workflow:
+    name: Push Buf Resources
+    uses: lockerstock/github-actions/.github/workflows/reusable-push-buf.yaml@main
+    secrets:
+      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}

--- a/examples/verify-go.yaml
+++ b/examples/verify-go.yaml
@@ -1,0 +1,18 @@
+name: Pull Request Verification
+
+on:
+  pull_request:
+
+# Kill the workflow if the PR is updated with a new commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call-verify-go-microservice-workflow:
+    name: Verify Go Microservice
+    uses: lockerstock/github-actions/.github/workflows/reusable-verify-go-microservice.yaml@main
+    secrets:
+      GHA_ACCESS_USER: ${{ secrets.GHA_ACCESS_USER }}
+      GHA_ACCESS_TOKEN: ${{ secrets.GHA_ACCESS_TOKEN }}
+      BUF_TOKEN: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
# Overview
- New Changelog Auto-Releaser Action
  - On PR, will check for new changelog entries and error if not found
  - On push to `main`, will attempt to release a new tagged version if found
- `deploy-helm` action will now append deployment instructions to a release

## Related to:
- https://github.com/lockerstock/github-actions/issues/11