### PR TITLE
Buf Verification Action runs all steps regardless of failure on previous

### DIFF
--- a/.github/workflows/reusable-verify-go-microservice.yaml
+++ b/.github/workflows/reusable-verify-go-microservice.yaml
@@ -25,26 +25,32 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup buf CLI
+        id: buf
         uses: bufbuild/buf-setup-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint Protobuf sources
+        if: steps.buf.outcome == 'success'
         uses: bufbuild/buf-lint-action@v1
         with:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
 
       - name: Build Protobuf sources
+        if: steps.buf.outcome == 'success' && always()
         run: buf build
 
       - name: Format Protobuf sources
+        if: steps.buf.outcome == 'success' && always()
         run: buf format -w
 
       - name: Generate Protobuf server/clients
+        if: steps.buf.outcome == 'success' && always()
         run: buf generate
 
       - name: Breaking Change Detection
         uses: bufbuild/buf-breaking-action@v1
+        if: steps.buf.outcome == 'success' && always()
         id: breaking
         with:
           input: proto/api
@@ -53,6 +59,7 @@ jobs:
           buf_input_https_password: ${{ secrets.GHA_ACCESS_TOKEN }}
 
       - name: Compare proto/ directory for changes
+        if: always()
         run: |
           if [ "$(git diff --ignore-space-at-eol proto/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build.  See status below:"

--- a/deploy-helm/action.yaml
+++ b/deploy-helm/action.yaml
@@ -243,7 +243,7 @@ runs:
           ### Upgrade/install Helm chart
 
           ```shell
-          helm upgrade --install ${{ github.event.repository.name }} ${{ github.repository_owner }}/${{ steps.chart.outputs.chart }}
+          helm upgrade --install ${{ github.event.repository.name }} ${{ github.repository_owner }}/${{ steps.chart.outputs.chart }} \
             --version ${{ steps.repo_version.outputs.version }} \
             -f values.yaml \
             --namespace production


### PR DESCRIPTION
# Overview
- It was noticed that when one Buf step fails it causes the entire chain to get skipped which in cases with breaking changes where an admin needs to approve it they could miss important changes due to skipped steps.
- Also fixed a command in the `deploy-helm` action when generating release deployment info text.